### PR TITLE
StreamBuf closure returns is_eof flag

### DIFF
--- a/src/byte/cat.rs
+++ b/src/byte/cat.rs
@@ -49,7 +49,7 @@ impl CatStream {
         self.cache.fill_buf(request, |request, buf| {
             if self.i >= self.srcs.len() {
                 debug_assert!(self.dup == 0);
-                return Ok(false);
+                return Ok(true);
             }
 
             // consume the last stream
@@ -58,7 +58,7 @@ impl CatStream {
             self.i += is_eof as usize;
             if self.i >= self.srcs.len() {
                 self.dup = 0;
-                return Ok(false);
+                return Ok(true);
             }
 
             let (is_eof_next, bytes) = self.srcs[self.i].fill_buf(request)?;
@@ -68,7 +68,7 @@ impl CatStream {
             self.dup = bytes;
 
             is_eof = is_eof_next;
-            Ok(is_eof && bytes == 0)
+            Ok(false)
         })
     }
 }

--- a/src/byte/cut.rs
+++ b/src/byte/cut.rs
@@ -131,19 +131,13 @@ impl ByteStream for CutStream {
             let (is_eof, bytes) = self.src.fill_buf(BLOCK_SIZE)?;
             let bytes = self.cutter.max_consume(is_eof, bytes);
 
-            if !is_eof && bytes == 0 {
-                self.src.consume(0);
-                return Ok(true);
-            }
-
-            let prev_len = buf.len();
             let stream = self.src.as_slice();
             self.cutter.accumulate(self.src_consumed, is_eof, bytes, stream, buf)?;
 
             self.src.consume(bytes);
             self.src_consumed += bytes;
 
-            Ok(!is_eof && buf.len() == prev_len)
+            Ok(is_eof)
         })
     }
 

--- a/src/byte/raw.rs
+++ b/src/byte/raw.rs
@@ -30,8 +30,8 @@ impl RawStream {
 impl ByteStream for RawStream {
     fn fill_buf(&mut self, request: usize) -> Result<(bool, usize)> {
         self.buf.fill_buf(request, |_, buf| {
-            buf.fill_uninit(BLOCK_SIZE, |arr| Ok(self.src.read(arr)?))?;
-            Ok(false)
+            let len = buf.fill_uninit(BLOCK_SIZE, |arr| Ok(self.src.read(arr)?))?;
+            Ok(len == 0)
         })
     }
 

--- a/src/byte/tee.rs
+++ b/src/byte/tee.rs
@@ -89,8 +89,11 @@ impl ByteStream for TeeStreamReader {
                 }
                 self.buf.fill_buf(request, |_, buf| {
                     cache.file.seek(SeekFrom::Start(self.offset as u64)).unwrap();
-                    self.offset += buf.fill_uninit(BLOCK_SIZE, |buf| Ok(cache.file.read(buf)?))?;
-                    Ok(false)
+
+                    let len = buf.fill_uninit(BLOCK_SIZE, |buf| Ok(cache.file.read(buf)?))?;
+                    self.offset += len;
+
+                    Ok(len == 0)
                 })
             }
             _ => panic!("failed to lock cache."),

--- a/src/byte/text.rs
+++ b/src/byte/text.rs
@@ -32,8 +32,8 @@ impl GaplessTextStream {
 impl ByteStream for GaplessTextStream {
     fn fill_buf(&mut self, request: usize) -> Result<(bool, usize)> {
         self.buf.fill_buf(request, |_, buf| {
-            self.inner.read_line(buf)?;
-            Ok(false)
+            let (fwd, _, _) = self.inner.read_line(buf)?;
+            Ok(fwd == 0)
         })
     }
 

--- a/src/byte/text.rs
+++ b/src/byte/text.rs
@@ -168,7 +168,8 @@ impl ByteStream for TextStream {
         let filler = self.buf.filler();
         self.buf.fill_buf(request, |_, buf| {
             if self.line.offset == usize::MAX {
-                return Ok(false);
+                // it has already reached EOF
+                return Ok(true);
             }
 
             let next_offset = std::cmp::min(self.offset + BLOCK_SIZE, self.line.offset);
@@ -186,7 +187,7 @@ impl ByteStream for TextStream {
 
             let (fwd, next_offset) = self.line.fill_buf()?;
             if fwd == 0 {
-                return Ok(false);
+                return Ok(true);
             }
             if self.offset > next_offset {
                 return Err(anyhow!(
@@ -195,10 +196,7 @@ impl ByteStream for TextStream {
                     &self.line.src.format_cache(true)
                 ));
             }
-
-            // the buffer may not grow even if the input stream has not reached EOF,
-            // so try the next patch forcibly
-            Ok(true)
+            Ok(false)
         })
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -442,16 +442,11 @@ fn test_pipeline() {
             let mut buf = StreamBuf::new();
             buf.fill_buf(BLOCK_SIZE, |request, buf| {
                 let (is_eof, bytes) = stream.fill_buf(request)?;
-
-                if is_eof && bytes == 0 {
-                    return Ok(false);
-                }
-
                 let slice = stream.as_slice();
                 buf.extend_from_slice(&slice[..bytes]);
                 stream.consume(bytes);
 
-                Ok(true)
+                Ok(is_eof)
             })
             .unwrap();
 


### PR DESCRIPTION
that indicates the source of the node has starved and the node won't extend the buffer any more. is more straightforward than the current `force_try_next` flag.